### PR TITLE
Removed Random.all, included RandomTools.h explicitly

### DIFF
--- a/src/ALE.h
+++ b/src/ALE.h
@@ -5,7 +5,7 @@
 
 #include <iostream>
 #include <Bpp/Phyl/BipartitionTools.h>
-#include <Bpp/Numeric/Random.all>
+#include <Bpp/Numeric/Random/RandomTools.h>
 #include <Bpp/Numeric/NumConstants.h>
 #include <Bpp/Phyl/TreeTemplate.h>
 #include <Bpp/Phyl/TreeTemplateTools.h>


### PR DESCRIPTION
The generic include files (*.all) were
removed from Bio++ Library in January 24, 2013
in commit d39443f.

Because of that Bio++ 2.10, 2.20 and
development versions don't have
the Random.all header file anymore.

This change should be backwards compatible as
Bpp/Numeric/Random/RandomTools.h wasn't
changed after the Random.all header file
was introduced in Bio++ commit 8b39bc0 in
December 10, 2010.

https://github.com/BioPP/bpp-core/commit/d39443f
https://github.com/BioPP/bpp-core/commit/8b39bc0