### PR TITLE
change Dockerfile

### DIFF
--- a/etc/filesDockerImage/Dockerfile
+++ b/etc/filesDockerImage/Dockerfile
@@ -1,58 +1,34 @@
-#FROM ubuntu:16.04
 FROM debian:jessie
 
 MAINTAINER Bastien Boussau bastien.boussau@univ-lyon1.fr
 
-RUN apt-get clean && apt-get update
-
-RUN apt-get install --no-install-recommends -qy make \
-    	    	    	wget \
-			git \
-			python3 \
-			#-setuptools \
-			#python-pip \
-
-
-# to install phyldog
-                        cmake \
-                        g++-4.9 \
-                        libboost-all-dev
-
-
+RUN apt-get update && \
+    apt-get clean && \
+    apt-get install --no-install-recommends -qy \
+                      cmake \
+                      g++-4.9 \
+                      git \
+                      libboost-all-dev \
+                      make \
+                      python3 \
+                      wget
 
 #### install bpp
 WORKDIR /opt
-RUN echo "deb http://biopp.univ-montp2.fr/repos/apt/ Trusty main" >> /etc/apt/sources.list;\
-    wget http://biopp.univ-montp2.fr/repos/apt/conf/biopp.gpg.key &&\
+RUN echo "deb http://biopp.univ-montp2.fr/repos/apt/ Trusty main" >> /etc/apt/sources.list; \
+    wget http://biopp.univ-montp2.fr/repos/apt/conf/biopp.gpg.key && \
     apt-key add biopp.gpg.key && \
-	apt-get update && \
+	  apt-get update && \
     apt-get install -qy libbpp-phyl-dev
 
 
 RUN git clone git://github.com/ssolo/ALE /usr/local/ALE && \
     mkdir /usr/local/ALE/build
-    
+
 WORKDIR /usr/local/ALE/build
 
 ENV LD_LIBRARY_PATH /usr/local/lib/
-RUN cmake ..  -DCMAKE_CXX_COMPILER=/usr/bin/g++-4.9 && make -j 4
-#########
 
-#### build a working directory
-#RUN mkdir -p /app
-WORKDIR /app
-
-#RUN ls /usr/local/ALE/build/bin
-
-#RUN ls /usr/local/ALE/build
-
-#RUN /usr/local/ALE/build/bin/ALEobserve
-
-# Copy the current directory contents into the container at /app
-ADD . /app
-
-
-ENTRYPOINT ["python3.4", "launcher_script.py"]
-
-#ENTRYPOINT ["/usr/local/ALE/build/bin/ALEobserve"]
-#ENTRYPOINT ["/bin/cat"]
+RUN cmake ..  -DCMAKE_CXX_COMPILER=/usr/bin/g++-4.9 && \
+    make -j 4 && \
+    for binary in $PWD/bin/*; do ln -s $binary /usr/local/bin/; done


### PR DESCRIPTION
Hej, 
I was trying to use the docker image, but there are still several issues that i think are unnecessary. I made some changes to the file, maybe you could have a look at them and include them if you think they are correct.

1. When I try to build the image, I am getting a lock error from `apt-get clean`. However, when I change the order to first call `apt-get update` everything builds smoothly.

2. When runnig the image with the `-w $PWD` option, It does not find the launcher script. I suggest simply linking the ALE binaries to /usr/local/bin. the usage does not change at all, it is easier to follow the Dockerfile and it works when mounting any volume to the image.

cheers,
max emil